### PR TITLE
block @rule selectors for css

### DIFF
--- a/src/__tests__/filter-style-values.test.ts
+++ b/src/__tests__/filter-style-values.test.ts
@@ -9,7 +9,7 @@ describe("filterStyleValues", () => {
     expect(filterStyleValues({})).toEqual({});
   });
 
-  it("prevents hexademcial statements", () => {
+  it("prevents hexadecimal statements", () => {
     const result = filterStyleValues({
       color: "\\6a\\61\\76\\61\\73\\63\\72\\69\\70\\74",
       fontWeight: "500",
@@ -23,7 +23,7 @@ describe("filterStyleValues", () => {
     expect(result).toEqual(expected);
   });
 
-  it("prevents @import statements", () => {
+  it("prevents at-rule statements", () => {
     const result = filterStyleValues({
       color: "@import",
       fontWeight: "500",

--- a/src/__tests__/validate-selector.test.ts
+++ b/src/__tests__/validate-selector.test.ts
@@ -29,6 +29,17 @@ describe("validateSelector", () => {
     expect(validate("@SUPPORTS (-webkit-appearance:none) {}")).toBe(false);
   });
 
+  it("@ command is present, but is @media is valid", () => {
+    expect(validate("@media")).toBe(true);
+    expect(validate("@MEDIA")).toBe(true);
+  });
+
+  it("@ command is present, but any other @ command is not allowed", () => {
+    expect(validate("@font-family")).toBe(false);
+    expect(validate("@FONT-FAMILY")).toBe(false);
+    expect(validate("@anything")).toBe(false);
+  });
+
   it("should return false if HTML is present", () => {
     expect(
       validate('</style><script>console.log("creditCard");</script> *'),

--- a/src/__tests__/validate-selector.test.ts
+++ b/src/__tests__/validate-selector.test.ts
@@ -29,12 +29,12 @@ describe("validateSelector", () => {
     expect(validate("@SUPPORTS (-webkit-appearance:none) {}")).toBe(false);
   });
 
-  it("@ command is present, but is @media is valid", () => {
+  it("is valid when the only at-rule present is @media", () => {
     expect(validate("@media")).toBe(true);
     expect(validate("@MEDIA")).toBe(true);
   });
 
-  it("@ command is present, but any other @ command is not allowed", () => {
+  it("is not valid when disallowed at-rules are present", () => {
     expect(validate("@font-family")).toBe(false);
     expect(validate("@FONT-FAMILY")).toBe(false);
     expect(validate("@anything")).toBe(false);

--- a/src/lib/filter-style-values.ts
+++ b/src/lib/filter-style-values.ts
@@ -23,6 +23,8 @@ const valueFilters = [
   // (could allow an exploiter to get around the url/expression/javascript rules)
   /\\/,
   /@import/i,
+  // block all other @-rules, to be extra safe
+  /@[a-z-]+/gi,
   /expression/i,
   /url/i,
   /javascript/i,

--- a/src/lib/filter-style-values.ts
+++ b/src/lib/filter-style-values.ts
@@ -22,9 +22,8 @@ const valueFilters = [
   // prevent hexadecimal characters
   // (could allow an exploiter to get around the url/expression/javascript rules)
   /\\/,
-  /@import/i,
   // block all other @-rules, to be extra safe
-  /@[a-z-]+/gi,
+  /@[a-z-]+/i,
   /expression/i,
   /url/i,
   /javascript/i,

--- a/src/lib/validate-selector.ts
+++ b/src/lib/validate-selector.ts
@@ -8,6 +8,9 @@ export function validateSelector(selector: string): boolean {
   if (/import/i.test(selector)) {
     return false;
   }
+  if (/@(?!media\b)[a-z-]+/gi.test(selector)) {
+    return false;
+  }
   if (/[{}]/.test(selector)) {
     return false;
   }

--- a/src/lib/validate-selector.ts
+++ b/src/lib/validate-selector.ts
@@ -8,7 +8,7 @@ export function validateSelector(selector: string): boolean {
   if (/import/i.test(selector)) {
     return false;
   }
-  if (/@(?!media\b)[a-z-]+/gi.test(selector)) {
+  if (/@(?!media\b)[a-z-]+/i.test(selector)) {
     return false;
   }
   if (/[{}]/.test(selector)) {


### PR DESCRIPTION
blocks exploits allowing xss by using different @ commands, e.g. (`@font-family`) to import malicious code
more precisely, should block all @ commands, excluding `@media`