### PR TITLE
ci: add CodeQL and dependency review security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,24 @@
+name: Security
+
+permissions:
+  contents: write
+  pull-requests: write
+  statuses: write
+  security-events: write
+  packages: read
+  actions: read
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  codeql-javascript:
+    uses: braintree/security-workflows/.github/workflows/codeql.yml@main
+    with:
+      language: javascript-typescript
+  dependency-review:
+    uses: braintree/security-workflows/.github/workflows/dependency-review.yml@main

--- a/src/lib/inject-stylesheet.ts
+++ b/src/lib/inject-stylesheet.ts
@@ -28,10 +28,51 @@ function buildRule(
         curriedKeysFilter,
       );
     });
+  } else {
+    result = curriedKeysFilter(styles);
+
+    const sanitized = filterStyleValues(result);
+
+    Object.keys(sanitized).forEach((rule) => {
+      constructedRule += rule + ":" + sanitized[rule] + ";";
+    });
+  }
+
+  constructedRule += "}";
+
+  return constructedRule;
+}
+
+export function injectStylesheet(
+  styles: Style = {},
+  propertyList: string[] = [],
+  isAllowlist?: boolean,
+): HTMLStyleElement {
+  let position = 0;
+  const styleElement = document.createElement("style");
+
+  (document.querySelector("head") as HTMLHeadElement).appendChild(styleElement);
+  const stylesheet = styleElement.sheet as CSSStyleSheet;
+
+  function curriedKeysFilter(styleObject: Style): Style {
+    return filterStyleKeys(styleObject, propertyList, isAllowlist);
+  }
+
+  Object.keys(styles).forEach((selector) => {
+    if (!validateSelector(selector)) {
+      return;
+    }
+
+    const constructedRule = buildRule(
+      selector,
+      styles[selector] as Style,
+      curriedKeysFilter,
+    );
+
+    try {
+      if (stylesheet.insertRule) {
+        stylesheet.insertRule(constructedRule, position);
       } else {
-        // addRule is the IE-only fallback for when insertRule is unavailable;
-        // unreachable in any modern browser or jsdom so coverage is suppressed.
-        /* istanbul ignore next */
         stylesheet.addRule(
           selector,
           constructedRule.replace(/^[^{]+/, "").replace(/[{}]/g, ""),

--- a/src/lib/inject-stylesheet.ts
+++ b/src/lib/inject-stylesheet.ts
@@ -28,51 +28,10 @@ function buildRule(
         curriedKeysFilter,
       );
     });
-  } else {
-    result = curriedKeysFilter(styles);
-
-    const sanitized = filterStyleValues(result);
-
-    Object.keys(sanitized).forEach((rule) => {
-      constructedRule += rule + ":" + sanitized[rule] + ";";
-    });
-  }
-
-  constructedRule += "}";
-
-  return constructedRule;
-}
-
-export function injectStylesheet(
-  styles: Style = {},
-  propertyList: string[] = [],
-  isAllowlist?: boolean,
-): HTMLStyleElement {
-  let position = 0;
-  const styleElement = document.createElement("style");
-
-  (document.querySelector("head") as HTMLHeadElement).appendChild(styleElement);
-  const stylesheet = styleElement.sheet as CSSStyleSheet;
-
-  function curriedKeysFilter(styleObject: Style): Style {
-    return filterStyleKeys(styleObject, propertyList, isAllowlist);
-  }
-
-  Object.keys(styles).forEach((selector) => {
-    if (!validateSelector(selector)) {
-      return;
-    }
-
-    const constructedRule = buildRule(
-      selector,
-      styles[selector] as Style,
-      curriedKeysFilter,
-    );
-
-    try {
-      if (stylesheet.insertRule) {
-        stylesheet.insertRule(constructedRule, position);
       } else {
+        // addRule is the IE-only fallback for when insertRule is unavailable;
+        // unreachable in any modern browser or jsdom so coverage is suppressed.
+        /* istanbul ignore next */
         stylesheet.addRule(
           selector,
           constructedRule.replace(/^[^{]+/, "").replace(/[{}]/g, ""),


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/security.yml` mirroring the pattern used in other repos (e.g. framebus)
- Runs CodeQL (`javascript-typescript`) and dependency review via the shared `braintree/security-workflows` reusable workflows
- Fixes the CodeQL check showing as \"skipping\" on PRs due to missing workflow config